### PR TITLE
Don't make concurrent requests when processing multiple records

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,27 +2,29 @@
 
 module.exports = (request, uri, auth, console) => (event, context, callback) => {
   console.log(`event-forwarder lambda received ${event.Records.length} event(s)`);
-  const promises = event.Records.map((record, index) => {
-    console.log(`Forwarding event ${index}`);
-    console.log(`    partitionKey: ${record.kinesis.partitionKey}`);
-    console.log(`    sequenceNumber: ${record.kinesis.sequenceNumber}`);
-    const options = {
-      method: 'POST',
-      uri,
-      body: record.kinesis,
-      json: true,
-      headers: { Authorization: auth },
-    };
+  const sendRecord = (promise, record, index) => (
+    promise.then(() => {
+      console.log(`Forwarding event ${index}`);
+      console.log(`    partitionKey: ${record.kinesis.partitionKey}`);
+      console.log(`    sequenceNumber: ${record.kinesis.sequenceNumber}`);
+      const options = {
+        method: 'POST',
+        uri,
+        body: record.kinesis,
+        json: true,
+        headers: { Authorization: auth },
+      };
 
-    return request(options)
-      .then(() => console.log(`Received success response from API for event ${record.kinesis.sequenceNumber}`))
-      .catch((e) => {
-        console.error(`Error sending event to API. Event: ${record.kinesis.sequenceNumber}, Error: ${e}`);
-        throw e;
-      });
-  });
+      return request(options)
+        .then(() => console.log(`Received success response from API for event ${record.kinesis.sequenceNumber}`))
+        .catch((e) => {
+          console.error(`Error sending event to API. Event: ${record.kinesis.sequenceNumber}, Error: ${e}`);
+          throw e;
+        });
+    })
+  );
 
-  return Promise.all(promises).then(
+  return event.Records.reduce(sendRecord, Promise.resolve()).then(
     () => { callback(null, 'ok'); },
     (err) => { callback(err); }
   );


### PR DESCRIPTION
The existing code, when called with multiple kinesis records, would map over them all immediately, sending out a concurrent requests for each record. This could cause the downstream API to receive multiple events at the same time, which would result in race conditions.

In practice, the above scenario should not be occurring, because [we have configured](https://github.com/rabblerouser/infra/blob/master/terraform/apps/docker-node-app/event-forwarder/event-forwarder.tf#L10) the event-forwarder to receive only a single record per event. So I don't think that this code is the cause of the bug that we've been seeing where emails get sent multiple times.

Nevertheless, it was still a bug laying dormant in the code, so it seems like a good idea to fix it.