### PR TITLE
Improve description of the architecture in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn test
 You can either run it natively:
 
 ```sh
-KINESIS_ENDPOINT'http://localhost:4567' STREAM_NAME='rabblerouser_stream' yarn start
+KINESIS_ENDPOINT='http://localhost:4567' STREAM_NAME='rabblerouser_stream' yarn start
 ```
 
 Or you can build the docker image like this...

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# Rabblerouser Event Forwarder
+# Rabble Rouser Event Forwarder
 
 [![Build Status](https://travis-ci.org/rabblerouser/event-forwarder.svg?branch=master)](https://travis-ci.org/rabblerouser/event-forwarder)
+
+This is the Event Forwarder application of the [Rabble Rouser](https://rabblerouser.team/) platform.
 
 A lambda function that receives all events from a kinesis stream and forwards them to an API over HTTP
 
 ## Background
 
-AWS Kinesis consumers need to be constantly polling the stream for new events (with a dedicated thread for it).
-NodeJS will struggle with this as it is single-threaded.
+This code base works when deployed as an [AWS Lambda](https://aws.amazon.com/lambda/) application.
 
-This is a lambda function that can do that dedicated job, and forward events to a consumer via HTTP.
+AWS Kinesis consumers need to be constantly polling the stream for new events (with a dedicated thread for it). NodeJS will struggle with this as it is single-threaded.
+
+This is a Lambda application that can do that dedicated job, and forward events to a consumer via an HTTP API.
 
 ## Install and run the tests
 
@@ -41,8 +44,10 @@ There is a build pipeline for this project, it publishes the zipped code to an s
 Actual deployment of this lambda function requires a few moving parts, such as IAM roles, a kinesis stream to subscribe
 to, and a consumer endpoint where events should be forwarded to.
 
-With that in mind, the easiest way to deploy this right now is as part of a whole Rabble Rouser stack. See
-[infra](https://github.com/rabblerouser/infra) for how to do that.
+With that in mind, the easiest way to deploy this right now is as part
+of a whole Rabble Rouser stack.
+See the [infra repository](https://github.com/rabblerouser/infra) for
+how to do that.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 This is the Event Forwarder application of the [Rabble Rouser](https://rabblerouser.team/) platform.
 
-The Event Forwarder is a service that receives all events from a kinesis stream, and forwards them to a web API.
+The Event Forwarder is a service that receives all events from an AWS
+Kinesis stream, and forwards them to a web API endpoint.
 
 ## Background
 
@@ -39,10 +40,16 @@ docker build -t rabblerouser/event-forwarder .
 
 ## Deployment
 
-There is a build pipeline for this project, it publishes the zipped code to an s3 bucket.
+There is a build pipeline for this project, it publishes the zipped code to an [Amazon S3](https://aws.amazon.com/s3/) bucket.
 
-Actual deployment of this application requires a few moving parts, such as IAM roles, a kinesis stream to subscribe
-to, and a consumer endpoint where events should be forwarded to.
+Actual deployment of this application requires a few moving parts:
+
+* [AWS IAM](https://aws.amazon.com/iam/) roles.
+
+* An [AWS Kinesis](https://aws.amazon.com/kinesis/) stream to
+  subscribe to.
+
+* A consumer HTTP API endpoint where events should be forwarded to.
 
 With that in mind, the easiest way to deploy this right now is as part
 of a whole Rabble Rouser stack.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@
 
 A lambda function that receives all events from a kinesis stream and forwards them to an API over HTTP
 
-## Background.
+## Background
+
 AWS Kinesis consumers need to be constantly polling the stream for new events (with a dedicated thread for it).
 NodeJS will struggle with this as it is single-threaded.
 
 This is a lambda function that can do that dedicated job, and forward events to a consumer via HTTP.
 
 ## Install and run the tests
+
 ```sh
 yarn
 yarn test
 ```
 
 ## Run it locally
+
 You can either run it natively:
 
 ```sh
@@ -24,6 +27,7 @@ KINESIS_ENDPOINT'http://localhost:4567' STREAM_NAME='rabblerouser_stream' yarn s
 ```
 
 Or you can build the docker image like this...
+
 ```sh
 docker build -t rabblerouser/event-forwarder .
 ```
@@ -31,6 +35,7 @@ docker build -t rabblerouser/event-forwarder .
 ... and then run it with docker-compose. E.g. see [core](https://github.com/rabblerouser/core).
 
 ## Deployment
+
 There is a build pipeline for this project, it publishes the zipped code to an s3 bucket.
 
 Actual deployment of this lambda function requires a few moving parts, such as IAM roles, a kinesis stream to subscribe
@@ -83,6 +88,7 @@ This lambda function sends an HTTP POST request to a configurable endpoint, with
 ```
 
 ## Error handling
+
 Lambda functions always notify the caller as to whether the function finished successfully or not. When the event source
 is a kinesis stream, success means that the next batch of events can be sent, whereas failure means that the batch needs
 to be retried.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the Event Forwarder application of the [Rabble Rouser](https://rabblerouser.team/) platform.
 
-A lambda function that receives all events from a kinesis stream and forwards them to an API over HTTP
+The Event Forwarder is a service that receives all events from a kinesis stream, and forwards them to a web API.
 
 ## Background
 
@@ -12,7 +12,7 @@ This code base works when deployed as an [AWS Lambda](https://aws.amazon.com/lam
 
 AWS Kinesis consumers need to be constantly polling the stream for new events (with a dedicated thread for it). NodeJS will struggle with this as it is single-threaded.
 
-This is a Lambda application that can do that dedicated job, and forward events to a consumer via an HTTP API.
+This is an application that can do that dedicated job, and forward events to a consumer via an HTTP API endpoint.
 
 ## Install and run the tests
 
@@ -41,7 +41,7 @@ docker build -t rabblerouser/event-forwarder .
 
 There is a build pipeline for this project, it publishes the zipped code to an s3 bucket.
 
-Actual deployment of this lambda function requires a few moving parts, such as IAM roles, a kinesis stream to subscribe
+Actual deployment of this application requires a few moving parts, such as IAM roles, a kinesis stream to subscribe
 to, and a consumer endpoint where events should be forwarded to.
 
 With that in mind, the easiest way to deploy this right now is as part
@@ -53,7 +53,7 @@ how to do that.
 
 ### Input
 
-This lambda function receives an event object from kinesis that looks like this:
+This application receives an event object from Kinesis that looks like this:
 
 ```js
 {
@@ -80,7 +80,7 @@ This lambda function receives an event object from kinesis that looks like this:
 
 ### Output
 
-This lambda function sends an HTTP POST request to a configurable endpoint, with a JSON body that looks like this:
+This application sends an HTTP POST request to a configurable endpoint, with a JSON body that looks like this:
 
 ```json
 {
@@ -94,18 +94,18 @@ This lambda function sends an HTTP POST request to a configurable endpoint, with
 
 ## Error handling
 
-Lambda functions always notify the caller as to whether the function finished successfully or not. When the event source
+AWS Lambda applications always notify the caller as to whether the function finished successfully or not. When the event source
 is a kinesis stream, success means that the next batch of events can be sent, whereas failure means that the batch needs
 to be retried.
 
-Success/failure for this event forwarder lambda is based on the HTTP status code of the service that it POSTs events to.
+Success/failure for this Event Forwarder is based on the HTTP status code of the service that it POSTs events to.
 This means that if the service is down, or failing for some reason, the events will be retried until the service
 responds with a success code.
 
 The other thing to remember is that the lambda can receive a batch multiple of events in a single call. This is
 problematic if some of the events in the batch were processed successfully and others failed, especially if you
-need to be sure that each event is only processed once. For that reason, it's recommended that this lambda function is
-deployed with a maximum batch size of 1 in its configuration. This ensures that each individual event can succeed or
+need to be sure that each event is only processed once. For that reason, it's recommended that this application is
+deployed with a maximum batch size of 1 in its AWS Lambda configuration. This ensures that each individual event can succeed or
 fail atomically.
 
 Processing one event at a time is a bit of an anti-pattern, however. It would be good if we had a way for a batch of


### PR DESCRIPTION
The README document has some inconsistencies, and some misleading terminology. Clean up the instructions and formatting.